### PR TITLE
Simplifying matching routes and constructing responses

### DIFF
--- a/chapter-03/Cargo.toml
+++ b/chapter-03/Cargo.toml
@@ -9,6 +9,7 @@ tokio = { version = "1", features = ["macros"] }
 serde = "1.0.203"
 serde_json = "1.0.117"
 cuid2 = "0.1.2"
+http = "1.1.0"
 
 [[bin]]
 name = "serverless_link_shortener"

--- a/chapter-03/Cargo.toml
+++ b/chapter-03/Cargo.toml
@@ -9,7 +9,6 @@ tokio = { version = "1", features = ["macros"] }
 serde = "1.0.203"
 serde_json = "1.0.117"
 cuid2 = "0.1.2"
-http = "1.1.0"
 
 [[bin]]
 name = "serverless_link_shortener"

--- a/chapter-03/src/main.rs
+++ b/chapter-03/src/main.rs
@@ -17,7 +17,7 @@ async fn function_handler(
         Method::POST => {
             if let Some(shorten_url_request) = event.payload::<ShortenUrlRequest>()? {
                 let shortened_url_response = url_shortener.shorten_url(shorten_url_request);
-                Ok(json_response(&StatusCode::OK, &shortened_url_response)?)
+                json_response(&StatusCode::OK, &shortened_url_response)
             } else {
                 empty_response(&StatusCode::BAD_REQUEST)
             }
@@ -32,8 +32,7 @@ async fn function_handler(
             if link_id.is_empty() {
                 empty_response(&StatusCode::NOT_FOUND)
             } else if let Some(url) = url_shortener.retrieve_url(link_id) {
-                let response = redirect_response(&url)?;
-                Ok(response)
+                redirect_response(&url)
             } else {
                 Ok(empty_response(&StatusCode::NOT_FOUND)?)
             }

--- a/chapter-03/src/main.rs
+++ b/chapter-03/src/main.rs
@@ -1,5 +1,6 @@
 use crate::core::{ShortenUrlRequest, UrlShortener};
 use crate::utils::generate_api_response;
+use http::Method;
 use lambda_http::http::StatusCode;
 use lambda_http::{
     run, service_fn, tracing, Error, IntoResponse, Request, RequestExt, RequestPayloadExt, Response,
@@ -14,8 +15,8 @@ async fn function_handler(
 ) -> Result<impl IntoResponse, Error> {
     // Manually writing a router in Lambda is not a best practice, in practice you would either use seperate Lambda functions per endpoint or use a web framework like Actix or Axum inside Lambda.
     // This is purely for demonstration purposes to allow us to build a functioning URL shortener and share memory between GET and POST requests.
-    match event.method().as_str() {
-        "POST" => {
+    match event.method() {
+        &Method::POST => {
             let shorten_url_request_body = event.payload::<ShortenUrlRequest>()?;
 
             match shorten_url_request_body {
@@ -29,7 +30,7 @@ async fn function_handler(
                 }
             }
         }
-        "GET" => {
+        &Method::GET => {
             let link_id = event
                 .path_parameters_ref()
                 .and_then(|params| params.first("linkId"))

--- a/chapter-03/src/main.rs
+++ b/chapter-03/src/main.rs
@@ -20,12 +20,13 @@ async fn function_handler(
                 let shortened_url_response = url_shortener.shorten_url(shorten_url_request);
                 Ok(generate_api_response(
                     &StatusCode::OK,
-                    &serde_json::to_string(&shortened_url_response).unwrap(),
+                    serde_json::to_string(&shortened_url_response).unwrap(),
                 )?)
             } else {
-                generate_api_response(&StatusCode::BAD_REQUEST, "Bad Request")
+                generate_api_response(&StatusCode::BAD_REQUEST, "Bad Request".to_string())
             }
         }
+
         &Method::GET => {
             let link_id = event
                 .path_parameters_ref()
@@ -33,7 +34,7 @@ async fn function_handler(
                 .unwrap_or("");
 
             if link_id.is_empty() {
-                generate_api_response(&StatusCode::NOT_FOUND, "Not Found")
+                generate_api_response(&StatusCode::NOT_FOUND, "Not Found".to_string())
             
             } else if let Some(url) = url_shortener.retrieve_url(link_id) {
                 let response = Response::builder()
@@ -41,15 +42,14 @@ async fn function_handler(
                     .header("Location", url)
                     .body("".to_string())
                     .map_err(Box::new)?;
-
                 Ok(response)
             
             } else {
-                Ok(generate_api_response(&StatusCode::NOT_FOUND, "Not Found")?)
+                Ok(generate_api_response(&StatusCode::NOT_FOUND, "Not Found".to_string())?)
             }
-
         }
-        _ => generate_api_response(&StatusCode::METHOD_NOT_ALLOWED, "Method Not Allowed"),
+
+        _ => generate_api_response(&StatusCode::METHOD_NOT_ALLOWED, "Method Not Allowed".to_string()),
     }
 }
 

--- a/chapter-03/src/main.rs
+++ b/chapter-03/src/main.rs
@@ -1,10 +1,9 @@
 use crate::core::{ShortenUrlRequest, UrlShortener};
-use crate::utils::generate_api_response;
-use http::Method;
-use lambda_http::http::StatusCode;
 use lambda_http::{
-    run, service_fn, tracing, Error, IntoResponse, Request, RequestExt, RequestPayloadExt, Response,
+    http::{Method, StatusCode},
+    run, service_fn, tracing, Error, IntoResponse, Request, RequestExt, RequestPayloadExt,
 };
+use utils::{empty_response, json_response, redirect_response};
 mod core;
 mod utils;
 
@@ -14,42 +13,33 @@ async fn function_handler(
 ) -> Result<impl IntoResponse, Error> {
     // Manually writing a router in Lambda is not a best practice, in practice you would either use seperate Lambda functions per endpoint or use a web framework like Actix or Axum inside Lambda.
     // This is purely for demonstration purposes to allow us to build a functioning URL shortener and share memory between GET and POST requests.
-    match event.method() {
-        &Method::POST => {
+    match *event.method() {
+        Method::POST => {
             if let Some(shorten_url_request) = event.payload::<ShortenUrlRequest>()? {
                 let shortened_url_response = url_shortener.shorten_url(shorten_url_request);
-                Ok(generate_api_response(
-                    &StatusCode::OK,
-                    serde_json::to_string(&shortened_url_response).unwrap(),
-                )?)
+                Ok(json_response(&StatusCode::OK, &shortened_url_response)?)
             } else {
-                generate_api_response(&StatusCode::BAD_REQUEST, "Bad Request".to_string())
+                empty_response(&StatusCode::BAD_REQUEST)
             }
         }
 
-        &Method::GET => {
+        Method::GET => {
             let link_id = event
                 .path_parameters_ref()
                 .and_then(|params| params.first("linkId"))
                 .unwrap_or("");
 
             if link_id.is_empty() {
-                generate_api_response(&StatusCode::NOT_FOUND, "Not Found".to_string())
-            
+                empty_response(&StatusCode::NOT_FOUND)
             } else if let Some(url) = url_shortener.retrieve_url(link_id) {
-                let response = Response::builder()
-                    .status(&StatusCode::FOUND)
-                    .header("Location", url)
-                    .body("".to_string())
-                    .map_err(Box::new)?;
+                let response = redirect_response(&url)?;
                 Ok(response)
-            
             } else {
-                Ok(generate_api_response(&StatusCode::NOT_FOUND, "Not Found".to_string())?)
+                Ok(empty_response(&StatusCode::NOT_FOUND)?)
             }
         }
 
-        _ => generate_api_response(&StatusCode::METHOD_NOT_ALLOWED, "Method Not Allowed".to_string()),
+        _ => empty_response(&StatusCode::METHOD_NOT_ALLOWED),
     }
 }
 

--- a/chapter-03/src/utils.rs
+++ b/chapter-03/src/utils.rs
@@ -1,11 +1,34 @@
 use lambda_http::http::StatusCode;
 use lambda_http::{Error, Response};
+use serde::Serialize;
 
-pub fn generate_api_response(status: &StatusCode, body: String) -> Result<Response<String>, Error> {
+pub fn redirect_response(location: &str) -> Result<Response<String>, Error> {
+    let response = Response::builder()
+        .status(&StatusCode::FOUND)
+        .header("Location", location)
+        .body("".to_string())
+        .map_err(Box::new)?;
+
+    Ok(response)
+}
+
+pub fn empty_response(status: &StatusCode) -> Result<Response<String>, Error> {
+    let response = Response::builder()
+        .status(status)
+        .body("".to_string())
+        .map_err(Box::new)?;
+
+    Ok(response)
+}
+
+pub fn json_response(
+    status: &StatusCode,
+    body: &impl Serialize,
+) -> Result<Response<String>, Error> {
     let response = Response::builder()
         .status(status)
         .header("content-type", "application/json")
-        .body(body)
+        .body(serde_json::to_string(&body).unwrap())
         .map_err(Box::new)?;
 
     Ok(response)

--- a/chapter-03/src/utils.rs
+++ b/chapter-03/src/utils.rs
@@ -1,9 +1,9 @@
 use lambda_http::http::StatusCode;
 use lambda_http::{Error, Response};
 
-pub fn generate_api_response(status: u16, body: &str) -> Result<Response<String>, Error> {
+pub fn generate_api_response(status: &StatusCode, body: &str) -> Result<Response<String>, Error> {
     let response = Response::builder()
-        .status(StatusCode::from_u16(status).unwrap())
+        .status(status)
         .header("content-type", "application/json")
         .body(body.to_string())
         .map_err(Box::new)?;

--- a/chapter-03/src/utils.rs
+++ b/chapter-03/src/utils.rs
@@ -1,11 +1,11 @@
 use lambda_http::http::StatusCode;
 use lambda_http::{Error, Response};
 
-pub fn generate_api_response(status: &StatusCode, body: &str) -> Result<Response<String>, Error> {
+pub fn generate_api_response(status: &StatusCode, body: String) -> Result<Response<String>, Error> {
     let response = Response::builder()
         .status(status)
         .header("content-type", "application/json")
-        .body(body.to_string())
+        .body(body)
         .map_err(Box::new)?;
 
     Ok(response)

--- a/chapter-04-challenge/src/utils.rs
+++ b/chapter-04-challenge/src/utils.rs
@@ -1,11 +1,34 @@
 use lambda_http::http::StatusCode;
 use lambda_http::{Error, Response};
+use serde::Serialize;
 
-pub fn generate_api_response(status: u16, body: &str) -> Result<Response<String>, Error> {
+pub fn redirect_response(location: &str) -> Result<Response<String>, Error> {
     let response = Response::builder()
-        .status(StatusCode::from_u16(status).unwrap())
+        .status(&StatusCode::FOUND)
+        .header("Location", location)
+        .body("".to_string())
+        .map_err(Box::new)?;
+
+    Ok(response)
+}
+
+pub fn empty_response(status: &StatusCode) -> Result<Response<String>, Error> {
+    let response = Response::builder()
+        .status(status)
+        .body("".to_string())
+        .map_err(Box::new)?;
+
+    Ok(response)
+}
+
+pub fn json_response(
+    status: &StatusCode,
+    body: &impl Serialize,
+) -> Result<Response<String>, Error> {
+    let response = Response::builder()
+        .status(status)
         .header("content-type", "application/json")
-        .body(body.to_string())
+        .body(serde_json::to_string(&body).unwrap())
         .map_err(Box::new)?;
 
     Ok(response)

--- a/chapter-04/src/utils.rs
+++ b/chapter-04/src/utils.rs
@@ -1,11 +1,34 @@
 use lambda_http::http::StatusCode;
 use lambda_http::{Error, Response};
+use serde::Serialize;
 
-pub fn generate_api_response(status: u16, body: &str) -> Result<Response<String>, Error> {
+pub fn redirect_response(location: &str) -> Result<Response<String>, Error> {
     let response = Response::builder()
-        .status(StatusCode::from_u16(status).unwrap())
+        .status(&StatusCode::FOUND)
+        .header("Location", location)
+        .body("".to_string())
+        .map_err(Box::new)?;
+
+    Ok(response)
+}
+
+pub fn empty_response(status: &StatusCode) -> Result<Response<String>, Error> {
+    let response = Response::builder()
+        .status(status)
+        .body("".to_string())
+        .map_err(Box::new)?;
+
+    Ok(response)
+}
+
+pub fn json_response(
+    status: &StatusCode,
+    body: &impl Serialize,
+) -> Result<Response<String>, Error> {
+    let response = Response::builder()
+        .status(status)
         .header("content-type", "application/json")
-        .body(body.to_string())
+        .body(serde_json::to_string(&body).unwrap())
         .map_err(Box::new)?;
 
     Ok(response)


### PR DESCRIPTION
Hi,

I'm reading your book, I really like it!

I'm a rust beginner. While coding along at home and digging into what means what, I stumbled upon some possible code tweakings for chapter 3, which I'm sending below in case they might interrest you.

* [matching on `Method` enums instead of string](https://github.com/rust-lambda/code-samples/commit/1b0170bc7ccbdba9995bf79bf8f5efa49b3becd1)

* Similarly, using [`StatusCode` enum instead of parsing integers](https://github.com/rust-lambda/code-samples/commit/c7f34bbe6aa9a63710df1b8ac260f7afbe26393d), which makes the code more readable and avoids one call to `.unwrap()`

* Maybe it's just my personnal preference, I find [the `if let ... = ` matching syntax for `Option` more readable](https://github.com/rust-lambda/code-samples/commit/69519d04f6c76f22d49afb13b7200bdff1e27407)

* Other opinionated change: I [let the `generate_api_response()` take full ownership of the `Body`](https://github.com/rust-lambda/code-samples/commit/adf3c0273586f78732e8bb6a257910870c7cbdbe)  instead of passing it as reference, since it's normally meant to be called last in the code flow, it avoids `clone()`ing the response to the POST method right after creating it, and it's inline with how the `Response::builder()` is structured.

One last aspect that was puzzling me was that sometimes the code is returning the output of `generate_api_response(()` directly, whereas sometimes it's unrapping it with `?` then immediately re-bundling it into another `Ok`. Maybe there's some error we want to let bubble up in some cases that I don't understand, so I didn't dare to touch that part :smile: 

I hope you find some of this useful, let me know your thoughts! 